### PR TITLE
Add support for Py3.6 and drop Py3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zope.container
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 *.so
 .tox
 .coverage
+htmlcov/
 nosetests.xml
 coverage.xml
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,24 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35
-env:
-    - TOXENV=py27
-    - TOXENV=pypy
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py27-pure-zodb
+    - python: 2.7
+      env: PURE_PYTHON=1
+python:
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3.5-5.8.0
 install:
-    - pip install tox
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
+    - if [[ $PURE_PYTHON ]]; then pip install -U -e .[zodb,zcml]; fi
 script:
-    - tox --develop
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,16 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 4.1.0 (2015-05-22)
-------------------
+==================
 
 - Make ``zope.container._proxy.PytContainedProxyBase`` inherit directly
   from ``persistent.AbstractProxyBase``, removing a bunch of redundant
@@ -22,7 +23,7 @@ Changes
 - Drop deprecated BBB imports module, ``zope.container.dependency``.
 
 4.0.0 (2014-03-19)
-------------------
+==================
 
 - Add support for Python 3.4.
 
@@ -30,14 +31,14 @@ Changes
 
 
 4.0.0a3 (2013-02-28)
---------------------
+====================
 
 - Restore ``Folder`` pickle forward/backward compatibility with
   version 3.12.0 after making it inherit from ``BTreeContainer.``
 
 
 4.0.0a2 (2013-02-21)
---------------------
+====================
 
 - Allow testing without checkouts of unreleased ``zope.publisher`` and
   ``ZODB``.
@@ -46,7 +47,7 @@ Changes
 
 
 4.0.0a1 (2013-02-20)
---------------------
+====================
 
 - Add support for Python 3.3.
 
@@ -75,7 +76,7 @@ Changes
 
 
 3.12.0 (2010-12-14)
--------------------
+===================
 
 - Fix detection of moving folders into itself or a subfolder of itself.
   (LP#118088)
@@ -85,7 +86,7 @@ Changes
 - Add ``zcml`` extra dependencies.
 
 3.11.1 (2010-04-30)
--------------------
+===================
 
 - Prefer the standard libraries doctest module to the one from ``zope.testing``.
 
@@ -98,14 +99,14 @@ Changes
 - ``checkName`` first checks the parameter type before the emptiness.
 
 3.11.0 (2009-12-31)
--------------------
+===================
 
 - Copy two trivial classes from ``zope.cachedescriptors`` into this package,
   which allows us to remove that dependency. We didn't actually use any
   caching properties as the dependency suggested.
 
 3.10.1 (2009-12-29)
--------------------
+===================
 
 - Move ``zope.copypastemove`` related tests into that package.
 
@@ -115,7 +116,7 @@ Changes
   compatibility problems with ``zope.testing`` 3.8.4.
 
 3.10.0 (2009-12-15)
--------------------
+===================
 
 - Break testing dependency on ``zope.app.testing``.
 
@@ -126,14 +127,14 @@ Changes
   ``zope.location``.
 
 3.9.1 (2009-10-18)
-------------------
+==================
 
 - Rerelease 3.9.0 as it had a broken Windows 2.6 egg.
 
 - Mark this project as part of the ZTK.
 
 3.9.0 (2009-08-28)
-------------------
+==================
 
 - Previous releases should be versioned 3.9.0 as they are not pure bugfix
   releases and worth a "feature" release, increasing feature version.
@@ -142,13 +143,13 @@ Changes
   should depend on version 3.9 or greater.
 
 3.8.3 (2009-08-27)
-------------------
+==================
 
 - Move ``IXMLRPCPublisher`` ZCML registrations for containers from
   ``zope.app.publisher.xmlrpc`` to ``zope.container`` for now.
 
 3.8.2 (2009-05-17)
-------------------
+==================
 
 - Rid ourselves of ``IContained`` interface.  This interface was moved
   to ``zope.location.interfaces``.  A b/w compat import still exists
@@ -179,13 +180,13 @@ Changes
   only.
 
 3.8.1 (2009-04-03)
-------------------
+==================
 
 - Fix misspackaged 3.8.0
 
 
 3.8.0 (2009-04-03)
-------------------
+==================
 
 - Change ``configure.zcml`` to not depend on ``zope.app.component``.
   Fixes: https://bugs.launchpad.net/bugs/348329
@@ -195,7 +196,7 @@ Changes
   easier reuse of the declaration.
 
 3.7.2 (2009-03-12)
-------------------
+==================
 
 - Fix: added missing ``ComponentLookupError``, missing since revision 95429
   and missing in last release.
@@ -209,7 +210,7 @@ Changes
   The default ``NameChooser`` is now also aware of reserved names.
 
 3.7.1 (2009-02-05)
-------------------
+==================
 
 - Raise more "Pythonic" errors from ``__setitem__``, losing the dependency
   on ``zope.exceptions``:
@@ -229,7 +230,7 @@ Changes
 - Strip out bogus develop eggs from ``buildout.cfg``.
 
 3.7.0 (2009-01-31)
-------------------
+==================
 
 - Split this package off ``zope.app.container``. This package is
   intended to have far less dependencies than ``zope.app.container``.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,15 @@
-``zope.container``
-==================
+====================
+ ``zope.container``
+====================
+
+
+.. image:: https://img.shields.io/pypi/v/zope.container.svg
+        :target: https://pypi.python.org/pypi/zope.container/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.container.svg
+        :target: https://pypi.org/project/zope.container/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.container.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.container
@@ -8,7 +18,13 @@
         :target: http://zopecontainer.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.container/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.container?branch=master
+
+
 This package define interfaces of container components, and provides
 container implementations such as a BTreeContainer and
 OrderedContainer, as well as the base class used by ``zope.site.folder``
 for the Folder implementation.
+
+Documentation is hosted at https://zopecontainer.readthedocs.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ where=src
 [aliases]
 dev = develop easy_install zope.container[test]
 docs = easy_install zope.container[docs]
+
+[bdist_wheel]
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ def read(*rnames):
         return f.read()
 
 def alltests():
-    import os
     import sys
     import unittest
     # use the zope.testrunner machinery to find all the
@@ -55,8 +54,8 @@ else:
     ext_modules = [Extension("zope.container._zope_container_contained",
                              [os.path.join("src", "zope", "container",
                                            "_zope_container_contained.c")
-                              ], include_dirs=['include']),
-                   ]
+                             ], include_dirs=['include']),
+    ]
 
 install_requires = [
     'setuptools',
@@ -81,7 +80,7 @@ install_requires = [
 
 
 setup(name='zope.container',
-      version=read('version.txt'),
+      version=read('version.txt').strip(),
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Container',
@@ -89,9 +88,9 @@ setup(name='zope.container',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
-      keywords = "zope container",
-      classifiers = [
+      ),
+      keywords="zope container",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -100,38 +99,46 @@ setup(name='zope.container',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
           'Framework :: Zope3',
-          ],
-      url='http:///zopecontainer.readthedocs.io',
+      ],
+      url='http://github.com/zopefoundation/zope.container',
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope'],
       ext_modules=ext_modules,
-      extras_require=dict(
-          docs=['Sphinx', 'repoze.sphinx.autointerface'],
-          test=['zope.testing', 'zope.testrunner'
-                ],
-          zcml=[
-                'zope.component[zcml]',
-                'zope.configuration',
-                'zope.security[zcml]>=4.0.0a3',
-                ],
-          zodb=['ZODB>=3.10',
-                ]),
+      extras_require={
+          'docs': [
+              'Sphinx',
+              'repoze.sphinx.autointerface',
+          ],
+          'test': [
+              'zope.testing',
+              'zope.testrunner',
+          ],
+          'zcml': [
+              'zope.component[zcml]',
+              'zope.configuration',
+              'zope.security[zcml]>=4.0.0a3',
+          ],
+          'zodb': [
+              'ZODB>=3.10',
+          ],
+      },
       install_requires=install_requires,
-      tests_require = [
+      tests_require=[
           'zope.testing',
-          'zope.testrunner'],
-      test_suite = '__main__.alltests',
-      include_package_data = True,
-      zip_safe = False,
-      )
+          'zope.testrunner',
+      ],
+      test_suite='__main__.alltests',
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,18 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py27-zodb,pypy-zodb,py27-pure-zodb,docs
+envlist = py27,pypy,py34,py35,py36,py27-zodb,pypy-zodb,py27-pure-zodb,docs
 
 [testenv]
-commands = python setup.py -q test -q
+commands =
+    zope-testrunner --test-path=src []
 deps =
-    six
-    persistent
-    BTrees
-    zope.event
-    zope.dottedname
-    zope.i18nmessageid
-    zope.interface
-    zope.component
-    zope.schema
-    zope.location
-    zope.security
-    zope.lifecycleevent
-    zope.filerepresentation
-    zope.size
-    zope.traversing
-    zope.publisher
-    zope.testrunner
-    zope.testing
+    .[test]
 
 [testenv:py27-zodb]
 basepython =
     python2.7
 deps =
     {[testenv]deps}
-    ZODB
+    .[zodb]
 
 [testenv:py27-pure-zodb]
 basepython =
@@ -37,27 +21,28 @@ setenv =
     PURE_PYTHON = 1
     PIP_CACHE_DIR = {envdir}/.cache
 deps =
-    {[testenv]deps}
-    ZODB
+    {[testenv:py27-zodb]deps}
+
 
 [testenv:pypy-zodb]
 basepython =
     pypy
 deps =
-    {[testenv]deps}
-    ZODB
+    {[testenv:py27-zodb]deps}
+
+
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report
 deps =
-    {[testenv]deps}
-    nose
+    {[testenv:py27-zodb]deps}
+    .[docs]
     coverage
-    nosexcover
 
 [testenv:docs]
 basepython =
@@ -67,5 +52,4 @@ commands =
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
     {[testenv]deps}
-    Sphinx
-    repoze.sphinx.autointerface
+    .[docs]


### PR DESCRIPTION
- Badges.
- Enable coveralls. Coverage appears to be less than 100%.
- DRY with dependencies in tox.ini

The doctests appear to be broken on Py2.7 for sure. I'll address that in a subsequent commit that enables them on CI, hopefully for all versions. We'll see what that does to the coverage numbers. 

I should probably also do a PURE_PYTHON+ZODB environment for Python 3 on CI. Since PyPy is a PURE_PYTHON environment by default, maybe just install ZODB there all the time?