### PR TITLE
Fix #21: Normalize the keys given to OrderedContainer.updateOrder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make ``OrderedContainer.updateOrder`` normalize and store text keys
+  the same way that ``__setitem__`` does. Fixes
+  https://github.com/zopefoundation/zope.container/issues/21
 
 
 4.2.0 (2017-07-31)

--- a/src/zope/container/contained.py
+++ b/src/zope/container/contained.py
@@ -344,6 +344,22 @@ def notifyContainerModified(object, *descriptions):
 
 _SENTINEL = object()
 
+def checkAndConvertName(name):
+    # Basic name checks, including converting bytes to text.
+    # Not a documented public API function.
+
+    if isinstance(name, bytes):
+        try:
+            name = name.decode('ascii')
+        except UnicodeError:
+            raise TypeError("name not unicode or ascii string")
+    elif not isinstance(name, text_type):
+        raise TypeError("name not unicode or ascii string")
+
+    if not name:
+        raise ValueError("empty names are not allowed")
+    return name
+
 def setitem(container, setitemf, name, object):
     """Helper function to set an item and generate needed events
 
@@ -550,16 +566,7 @@ def setitem(container, setitemf, name, object):
 
     """
     # Do basic name check:
-    if isinstance(name, bytes):
-        try:
-            name = name.decode('ascii')
-        except UnicodeError:
-            raise TypeError("name not unicode or ascii string")
-    elif not isinstance(name, text_type):
-        raise TypeError("name not unicode or ascii string")
-
-    if not name:
-        raise ValueError("empty names are not allowed")
+    name = checkAndConvertName(name)
 
     old = container.get(name, _SENTINEL)
     if old is object:

--- a/src/zope/container/ordered.py
+++ b/src/zope/container/ordered.py
@@ -22,6 +22,7 @@ from zope.container.interfaces import IOrderedContainer
 from zope.interface import implementer
 from zope.container.contained import Contained, setitem, uncontained
 from zope.container.contained import notifyContainerModified
+from zope.container.contained import checkAndConvertName
 
 @implementer(IOrderedContainer)
 class OrderedContainer(Persistent, Contained):
@@ -272,17 +273,14 @@ class OrderedContainer(Persistent, Contained):
         if len(order) != len(self._order):
             raise ValueError("Incompatible key set.")
 
-        was_dict = {}
-        will_be_dict = {}
-        new_order = PersistentList()
+        order = [checkAndConvertName(x) for x in order]
 
-        for i, obj in enumerate(order):
-            was_dict[self._order[i]] = 1
-            will_be_dict[obj] = 1
-            new_order.append(obj)
-
-        if will_be_dict != was_dict:
+        if frozenset(order) != frozenset(self._order):
             raise ValueError("Incompatible key set.")
 
-        self._order = new_order
+        if order == self._order:
+            return
+
+        self._order.sort(key=order.index)
+
         notifyContainerModified(self)

--- a/src/zope/container/ordered.py
+++ b/src/zope/container/ordered.py
@@ -281,6 +281,6 @@ class OrderedContainer(Persistent, Contained):
         if order == self._order:
             return
 
-        self._order.sort(key=order.index)
+        self._order[:] = order
 
         notifyContainerModified(self)

--- a/src/zope/container/tests/test_ordered.py
+++ b/src/zope/container/tests/test_ordered.py
@@ -102,14 +102,12 @@ class TestOrderedContainer(TestSampleContainer):
 
         self.assertEqual(keys, oc.keys())
 
+        # Updating with bytes keys...
         oc.updateOrder((b'b', b'a'))
-
+        # still produces text keys
         text_type = str if str is not bytes else unicode
         self.assertEqual(list(reversed(keys)), oc.keys())
         self.assertIsInstance(oc.keys()[0], text_type)
-
-        # It also kept the exact key objects as given
-        self.assertIs(oc.keys()[0], keys[1])
 
 
 def test_suite():

--- a/src/zope/container/tests/test_ordered.py
+++ b/src/zope/container/tests/test_ordered.py
@@ -92,6 +92,25 @@ class TestOrderedContainer(TestSampleContainer):
         self.assertIsNotNone(oc['foo'])
         self.assertEqual(None, oc['foo'])
 
+    def test_order_updateOrder_bytes(self):
+        # https://github.com/zopefoundation/zope.container/issues/21
+        from zope.container.ordered import OrderedContainer
+        keys = [u'a', u'b']
+        oc = OrderedContainer()
+        oc[keys[0]] = 0
+        oc[keys[1]] = 1
+
+        self.assertEqual(keys, oc.keys())
+
+        oc.updateOrder((b'b', b'a'))
+
+        text_type = str if str is not bytes else unicode
+        self.assertEqual(list(reversed(keys)), oc.keys())
+        self.assertIsInstance(oc.keys()[0], text_type)
+
+        # It also kept the exact key objects as given
+        self.assertIs(oc.keys()[0], keys[1])
+
 
 def test_suite():
     suite = unittest.TestSuite([


### PR DESCRIPTION
Also sort the existing list in place to avoid garbage and preserve the
actual key objects, and avoid sorting it if we don't need to.