### PR TITLE
Fix process of reference count during GC

### DIFF
--- a/src/zope/container/_zope_proxy_proxy.c
+++ b/src/zope/container/_zope_proxy_proxy.c
@@ -182,6 +182,7 @@ wrap_iternext(PyObject *self)
 static void
 wrap_dealloc(PyObject *self)
 {
+    PyObject_GC_UnTrack(self);
     (void) wrap_clear(self);
     self->ob_type->tp_free(self);
 }


### PR DESCRIPTION
    call PyObject_GC_UnTrack() in tp_dealloc()
    see the following sites for details:
    * https://bugs.python.org/issue31095
    * https://github.com/python/cpython/pull/2974