### PR TITLE
Use Python 3.6.2 on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,10 @@ jobs:
     - name: Python 3.6 wheels for MacOS
       os: osx
       language: generic
-      env: TERRYFY_PYTHON='macpython 3.6.0'
+      # NB: 3.6.0 causes https://github.com/nedbat/coveragepy/issues/703
+      # NB: 3.6.1 had that ABI regression (fixed in 3.6.2) and would be a bad
+      # version to use
+      env: TERRYFY_PYTHON='macpython 3.6.2'
     - name: Python 3.7 wheels for MacOS
       os: osx
       language: generic


### PR DESCRIPTION
It seems that 3.6.0 has a bug that causes https://github.com/nedbat/coveragepy/issues/703 ("Couldn't use data file '/Users/travis/build/zopefoundation/zope.container/.coverage': Safety level may not be changed inside a transaction" and a failed build from 'coverage run').