### PR TITLE
Ensure all objects have consistent resolution errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 env:
   global:
+    ZOPE_INTERFACE_STRICT_IRO: 1
     TWINE_USERNAME: zope.wheelbuilder
     TWINE_PASSWORD:
       secure: "G1ORcUIV439Iws2toGhxPvYvQKQt6L1wyXfIMspz2xtjJvQ2D1XrqK8dRYyQ0YaGLY/OAI8BrEdTp/l7jrhiG0gXMeAs0k1KFbp7ATahcVT8rWOzvcLGMAiYRVloQ3rz5x5HjMm0CWpDjo1MAeJMmesyq8RlmYzaMu4aw1mBd/Y="

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@
 
 - Drop support for the deprecated ``python setup.py test`` command.
 
+- Ensure all objects have consistent interface resolution orders. This
+  may slightly change the order of interfaces for ``ContainedProxy``
+  objects. See `issue 34 <https://github.com/zopefoundation/zope.container/issues/34>`_.
 
 4.3.0 (2019-11-11)
 ==================

--- a/src/zope/container/_util.py
+++ b/src/zope/container/_util.py
@@ -178,8 +178,16 @@ def use_c_impl(py_impl, name=None, globs=None):
             if static:
                 v = staticmethod(v)
             setattr(py_impl, k, v)
-        # copy the interface declarations.
+        # copy the interface declarations, being careful not
+        # to redeclare interfaces already implemented (through
+        # inheritance usually)
         implements = list(implementedBy(py_impl))
-        if implements:
+        implemented_by_c = implementedBy(c_impl)
+        implements = [
+            iface
+            for iface in implements
+            if not implemented_by_c.isOrExtends(iface)
+        ]
+        if implements: # pragma: no cover
             classImplements(c_impl, *implements)
     return c_impl

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     coverage
 setenv =
     PURE_PYTHON=0
+    ZOPE_INTERFACE_STRICT_IRO=1
     pure: PURE_PYTHON=1
     pypy: PURE_PYTHON=1
     pypy3: PURE_PYTHON=1


### PR DESCRIPTION
Based on #35, only the last commit is relevant.