### PR TITLE
Add support for Python 3.11.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11.0-alpha.7"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -143,7 +144,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
-          pip install -U coveralls coverage
 
       - name: Build zope.container
         run: |
@@ -152,9 +152,8 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
-          pip install -U coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install .[test]
+          pip install --pre .[test]
 
       - name: Check zope.container build
         run: |
@@ -169,7 +168,12 @@ jobs:
         # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
         # that's apparently a container action, and those don't run on
         # the Mac.
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && startsWith(runner.os, 'Mac') && !startsWith(matrix.python-version, 'pypy')
+        if: >
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+          && startsWith(runner.os, 'Mac')
+          && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.11.0-alpha.7')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -191,6 +195,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11.0-alpha.7"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -234,13 +239,15 @@ jobs:
       - name: Install zope.container
         run: |
           pip install -U wheel setuptools
-          pip install -U coverage coverage-python-version
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/zope.container-*whl -d src
-          pip install -U -e .[test]
+          pip install --pre -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
@@ -318,6 +325,7 @@ jobs:
           ZOPE_INTERFACE_STRICT_IRO: 1
         run: |
           sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+
   lint:
     needs: build-package
     runs-on: ${{ matrix.os }}
@@ -442,7 +450,9 @@ jobs:
         run: sudo chown -R $(whoami) ${{ steps.pip-cache.outputs.dir }}
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: >
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -31,6 +31,7 @@ for PYBIN in /opt/python/*/bin; do
     if \
        [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
+       [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
@@ -39,10 +40,10 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
-         cd /io/
-         "${PYBIN}/pip" install tox
-         "${PYBIN}/tox" -e py
-         cd ..
+          cd /io/
+          "${PYBIN}/pip" install tox
+          "${PYBIN}/tox" -e py
+          cd ..
         fi
         rm -rf /io/build /io/*.egg-info
     fi

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "ab709c2e22dff33a005b4237df8a2e0b6baf2f7b"
+commit-id = "dbaca5f3c7785b7bca563dabc5f440544069a8f9"
 
 [python]
 with-appveyor = true
@@ -44,6 +44,7 @@ additional-rules = [
     "include *.sh",
     "include compat.cfg",
     "recursive-include docs *.bat",
+    "recursive-include src *.h",
     "recursive-include src *.rst",
     "recursive-include src *.zcml",
     ]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "2d2c0e59a7eea3f9e0b02da6e5e35ff98c3c5956"
+commit-id = "ab709c2e22dff33a005b4237df8a2e0b6baf2f7b"
 
 [python]
 with-appveyor = true
 with-windows = false
 with-pypy = true
-with-future-python = false
+with-future-python = true
 with-legacy-python = true
 with-docs = true
 with-sphinx-doctests = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
  Changes
 =========
 
-4.5.1 (unreleased)
-==================
+4.6 (unreleased)
+================
 
-- Nothing changed yet.
+- Add support for Python 3.11 (as of 3.11.0a7).
 
 
 4.5.0 (2021-11-19)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+<!--
+Generated from:
+https://github.com/zopefoundation/meta/tree/master/config/c-code
+--> 
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
+include *.md
 include *.rst
 include *.txt
 include buildout.cfg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,5 +17,6 @@ recursive-include src *.py
 include *.sh
 include compat.cfg
 recursive-include docs *.bat
+recursive-include src *.h
 recursive-include src *.rst
 recursive-include src *.zcml

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@
         :target: https://pypi.org/project/zope.container/
         :alt: Supported Python versions
 
-.. image:: https://travis-ci.com/zopefoundation/zope.container.svg?branch=master
-        :target: https://travis-ci.com/zopefoundation/zope.container
+.. image:: https://github.com/zopefoundation/zope.container/actions/workflows/tests.yml/badge.svg
+        :target: https://github.com/zopefoundation/zope.container/actions/workflows/tests.yml
 
 .. image:: https://ci.appveyor.com/api/projects/status/iawcghgqox42af70/branch/master?svg=true
         :target: https://ci.appveyor.com/project/mgedmin/zope-container

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,10 @@ environment:
     - python: 39-x64
     - python: 310
     - python: 310-x64
+    # `multibuild` cannot install non-final versions as they are not on
+    # ftp.python.org, so we skip Python 3.11 until its final release:
+    # - python: 311
+    # - python: 311-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,14 @@ ignore =
     .editorconfig
     .meta.toml
     docs/_build/html/_sources/*
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ extras['test'] += (extras['zodb'] + extras['zcml'])
 
 
 setup(name='zope.container',
-      version='4.5.1.dev0',
+      version='4.6.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Container',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@
 import os
 import sys
 
-from setuptools import setup, find_packages, Extension
+from setuptools import Extension
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(*rnames):
@@ -141,6 +143,7 @@ install_requires = setup_requires + [
     'six',
     'zope.cachedescriptors',
     'zope.component',
+    'zope.deferredimport',
     'zope.dottedname',
     'zope.event',
     'zope.filerepresentation',

--- a/src/zope/container/_compat.h
+++ b/src/zope/container/_compat.h
@@ -1,0 +1,18 @@
+// Compatibility with Visual Studio 2013 and older which don't support
+// the inline keyword in C (only in C++): use __inline instead.
+#if (defined(_MSC_VER) && _MSC_VER < 1900 \
+     && !defined(__cplusplus) && !defined(inline))
+#  define PYCAPI_COMPAT_INLINE(TYPE static __inline TYPE
+#else
+#  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static inline TYPE
+#endif
+
+// bpo-39573 added Py_SET_TYPE() to Python 3.9.0a4
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+PYCAPI_COMPAT_STATIC_INLINE(void)
+_Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{
+    ob->ob_type = type;
+}
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE(_PyObject_CAST(ob), type)
+#endif

--- a/src/zope/container/_compat.h
+++ b/src/zope/container/_compat.h
@@ -2,7 +2,7 @@
 // the inline keyword in C (only in C++): use __inline instead.
 #if (defined(_MSC_VER) && _MSC_VER < 1900 \
      && !defined(__cplusplus) && !defined(inline))
-#  define PYCAPI_COMPAT_INLINE(TYPE static __inline TYPE
+#  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static __inline TYPE
 #else
 #  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static inline TYPE
 #endif

--- a/src/zope/container/_compat.h
+++ b/src/zope/container/_compat.h
@@ -7,6 +7,14 @@
 #  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static inline TYPE
 #endif
 
+// Cast argument to PyObject* type.
+#ifndef _PyObject_CAST
+#  define _PyObject_CAST(op) PYCAPI_COMPAT_CAST(PyObject*, op)
+#endif
+#ifndef _PyObject_CAST_CONST
+#  define _PyObject_CAST_CONST(op) PYCAPI_COMPAT_CAST(const PyObject*, op)
+#endif
+
 // bpo-39573 added Py_SET_TYPE() to Python 3.9.0a4
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
 PYCAPI_COMPAT_STATIC_INLINE(void)

--- a/src/zope/container/_compat.h
+++ b/src/zope/container/_compat.h
@@ -7,6 +7,15 @@
 #  define PYCAPI_COMPAT_STATIC_INLINE(TYPE) static inline TYPE
 #endif
 
+// C++ compatibility
+#ifdef __cplusplus
+#  define PYCAPI_COMPAT_CAST(TYPE, EXPR) reinterpret_cast<TYPE>(EXPR)
+#  define PYCAPI_COMPAT_NULL nullptr
+#else
+#  define PYCAPI_COMPAT_CAST(TYPE, EXPR) ((TYPE)(EXPR))
+#  define PYCAPI_COMPAT_NULL NULL
+#endif
+
 // Cast argument to PyObject* type.
 #ifndef _PyObject_CAST
 #  define _PyObject_CAST(op) PYCAPI_COMPAT_CAST(PyObject*, op)

--- a/src/zope/container/_proxy.py
+++ b/src/zope/container/_proxy.py
@@ -12,10 +12,10 @@
 #
 ##############################################################################
 
-from zope.proxy import AbstractPyProxyBase
-from zope.container._util import use_c_impl
-
 from persistent import Persistent
+from zope.proxy import AbstractPyProxyBase
+
+from zope.container._util import use_c_impl
 
 
 _MARKER = object()

--- a/src/zope/container/_util.py
+++ b/src/zope/container/_util.py
@@ -16,8 +16,8 @@ import os
 import sys
 import types
 
-from zope.interface import implementedBy
 from zope.interface import classImplements
+from zope.interface import implementedBy
 
 
 def _c_optimizations_required():

--- a/src/zope/container/_zope_container_contained.c
+++ b/src/zope/container/_zope_container_contained.c
@@ -33,6 +33,7 @@
 
 #include "Python.h"
 #include "cPersistence.h"
+#include "_compat.h"
 
 static PyObject *str_p_deactivate;
 
@@ -327,7 +328,7 @@ MOD_INIT(_zope_container_contained)
     return MOD_ERROR_VAL;
 
   ProxyType.tp_name = "zope.container.contained.ContainedProxyBase";
-  Py_TYPE(&ProxyType) = &PyType_Type;
+  Py_SET_TYPE(&ProxyType, &PyType_Type);
   ProxyType.tp_base = cPersistenceCAPI->pertype;
   ProxyType.tp_getattro = CP_getattro;
   ProxyType.tp_setattro = CP_setattro;

--- a/src/zope/container/btree.py
+++ b/src/zope/container/btree.py
@@ -15,14 +15,16 @@
 """
 __docformat__ = 'restructuredtext'
 
-from persistent import Persistent
-from BTrees.OOBTree import OOBTree
 from BTrees.Length import Length
-
-from zope.container.interfaces import IBTreeContainer
-from zope.container.contained import Contained, setitem, uncontained
-from zope.interface import implementer
+from BTrees.OOBTree import OOBTree
+from persistent import Persistent
 from zope.cachedescriptors.property import Lazy
+from zope.interface import implementer
+
+from zope.container.contained import Contained
+from zope.container.contained import setitem
+from zope.container.contained import uncontained
+from zope.container.interfaces import IBTreeContainer
 
 
 @implementer(IBTreeContainer)

--- a/src/zope/container/constraints.py
+++ b/src/zope/container/constraints.py
@@ -153,13 +153,15 @@ __docformat__ = 'restructuredtext'
 
 import sys
 
+import zope.schema
 from zope.cachedescriptors.property import readproperty
 from zope.dottedname.resolve import resolve
-import zope.schema
 from zope.interface import providedBy
-from zope.container.interfaces import InvalidItemType, InvalidContainerType
+
 from zope.container.i18n import ZopeMessageFactory as _
 from zope.container.interfaces import IContainer
+from zope.container.interfaces import InvalidContainerType
+from zope.container.interfaces import InvalidItemType
 
 
 def checkObject(container, name, object):

--- a/src/zope/container/contained.py
+++ b/src/zope/container/contained.py
@@ -17,33 +17,29 @@
 from six import text_type
 
 import zope.component
-
-from zope.interface import providedBy
+from zope.event import notify
 from zope.interface import Interface
 from zope.interface import implementedBy
-from zope.interface.declarations import getObjectSpecification
+from zope.interface import providedBy
 from zope.interface.declarations import Provides
-
-from zope.event import notify
-
-from zope.location.interfaces import ILocation, ISublocations
-from zope.location.interfaces import IContained
-
-from zope.security.checker import selectChecker, CombinedChecker
-
+from zope.interface.declarations import getObjectSpecification
+from zope.lifecycleevent import ObjectAddedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.lifecycleevent import ObjectMovedEvent
-from zope.lifecycleevent import ObjectAddedEvent
 from zope.lifecycleevent import ObjectRemovedEvent
+from zope.location.interfaces import IContained
+from zope.location.interfaces import ILocation
+from zope.location.interfaces import ISublocations
+from zope.security.checker import CombinedChecker
+from zope.security.checker import selectChecker
 
-
-from zope.container.i18n import ZopeMessageFactory as _
-from zope.container.interfaces import INameChooser
-from zope.container.interfaces import IReservedNames, NameReserved
-from zope.container.interfaces import IContainerModifiedEvent
-
-from zope.container._proxy import getProxiedObject
 from zope.container._proxy import ContainedProxyBase
+from zope.container._proxy import getProxiedObject
+from zope.container.i18n import ZopeMessageFactory as _
+from zope.container.interfaces import IContainerModifiedEvent
+from zope.container.interfaces import INameChooser
+from zope.container.interfaces import IReservedNames
+from zope.container.interfaces import NameReserved
 
 
 try:

--- a/src/zope/container/directory.py
+++ b/src/zope/container/directory.py
@@ -23,14 +23,14 @@ providing a file-system representation for containers:
 """
 __docformat__ = 'restructuredtext'
 
-from zope.interface import implementer
-
-from zope.component.interfaces import ISite
-from zope.container.folder import Folder
-from zope.security.proxy import removeSecurityProxy
-import zope.filerepresentation.interfaces
-
 from six.moves import map
+
+import zope.filerepresentation.interfaces
+from zope.component.interfaces import ISite
+from zope.interface import implementer
+from zope.security.proxy import removeSecurityProxy
+
+from zope.container.folder import Folder
 
 
 MARKER = object()

--- a/src/zope/container/find.py
+++ b/src/zope/container/find.py
@@ -16,7 +16,10 @@
 __docformat__ = 'restructuredtext'
 
 from zope.interface import implementer
-from .interfaces import IFind, IIdFindFilter, IObjectFindFilter
+
+from .interfaces import IFind
+from .interfaces import IIdFindFilter
+from .interfaces import IObjectFindFilter
 from .interfaces import IReadContainer
 
 

--- a/src/zope/container/folder.py
+++ b/src/zope/container/folder.py
@@ -15,7 +15,9 @@
 """
 __docformat__ = 'restructuredtext'
 from zope.interface import implementer
-from zope.container import btree, interfaces
+
+from zope.container import btree
+from zope.container import interfaces
 
 
 @implementer(interfaces.IContentContainer)

--- a/src/zope/container/i18n.py
+++ b/src/zope/container/i18n.py
@@ -17,4 +17,6 @@ __docformat__ = 'restructuredtext'
 
 # import this as _ to create i18n messages in the zope domain
 from zope.i18nmessageid import MessageFactory
+
+
 ZopeMessageFactory = MessageFactory('zope')

--- a/src/zope/container/interfaces.py
+++ b/src/zope/container/interfaces.py
@@ -15,23 +15,35 @@
 """
 __docformat__ = 'restructuredtext'
 
-from zope.interface import Interface, Invalid
+import zope.deferredimport
+from zope.interface import Interface
+from zope.interface import Invalid
+from zope.interface.common.mapping import IEnumerableMapping
 from zope.interface.common.mapping import IItemMapping
-from zope.interface.common.mapping import IReadMapping, IEnumerableMapping
+from zope.interface.common.mapping import IReadMapping
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 from zope.schema import Set
 
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
-
-# the following imports provide backwards compatibility for consumers;
-# do not remove them
-from zope.lifecycleevent.interfaces import IObjectAddedEvent
-from zope.lifecycleevent.interfaces import IObjectMovedEvent
-from zope.lifecycleevent.interfaces import IObjectRemovedEvent
-from zope.location.interfaces import IContained
-from zope.location.interfaces import ILocation
-# /end backwards compatibility imports
-
 from zope.container.i18n import ZopeMessageFactory as _
+
+
+zope.deferredimport.initialize()
+
+
+zope.deferredimport.deprecated(
+    "Some zope.container interfaces have been moved to"
+    " zope.lifecycleevent.interfaces, please import form there.",
+    IObjectAddedEvent='zope.lifecycleevent.interfaces:IObjectAddedEvent',
+    IObjectMovedEvent='zope.lifecycleevent.interfaces:IObjectMovedEvent',
+    IObjectRemovedEvent='zope.lifecycleevent.interfaces:IObjectRemovedEvent',
+)
+
+zope.deferredimport.deprecated(
+    "Some zope.container interfaces have been moved to"
+    " zope.location.interfaces, please import form there.",
+    IContained='zope.location.interfaces:IContained',
+    ILocation='zope.location.interfaces:ILocation',
+)
 
 
 class DuplicateIDError(KeyError):

--- a/src/zope/container/ordered.py
+++ b/src/zope/container/ordered.py
@@ -18,11 +18,14 @@ __docformat__ = 'restructuredtext'
 from persistent import Persistent
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
-from zope.container.interfaces import IOrderedContainer
 from zope.interface import implementer
-from zope.container.contained import Contained, setitem, uncontained
-from zope.container.contained import notifyContainerModified
+
+from zope.container.contained import Contained
 from zope.container.contained import checkAndConvertName
+from zope.container.contained import notifyContainerModified
+from zope.container.contained import setitem
+from zope.container.contained import uncontained
+from zope.container.interfaces import IOrderedContainer
 
 
 @implementer(IOrderedContainer)

--- a/src/zope/container/sample.py
+++ b/src/zope/container/sample.py
@@ -20,9 +20,12 @@ need a very different implementation.
 """
 __docformat__ = 'restructuredtext'
 
-from zope.container.interfaces import IContainer
 from zope.interface import implementer
-from zope.container.contained import Contained, setitem, uncontained
+
+from zope.container.contained import Contained
+from zope.container.contained import setitem
+from zope.container.contained import uncontained
+from zope.container.interfaces import IContainer
 
 
 @implementer(IContainer)

--- a/src/zope/container/size.py
+++ b/src/zope/container/size.py
@@ -16,9 +16,10 @@
 """
 __docformat__ = 'restructuredtext'
 
-from zope.container.i18n import ZopeMessageFactory as _
-from zope.size.interfaces import ISized
 from zope.interface import implementer
+from zope.size.interfaces import ISized
+
+from zope.container.i18n import ZopeMessageFactory as _
 
 
 @implementer(ISized)

--- a/src/zope/container/testing.py
+++ b/src/zope/container/testing.py
@@ -17,17 +17,20 @@ import re
 
 import zope.interface
 import zope.traversing.testing
-from zope import component
-from zope.component.testing import PlacelessSetup as CAPlacelessSetup
 from zope.component.eventtesting import PlacelessSetup as EventPlacelessSetup
-from zope.traversing.interfaces import ITraversable, IContainmentRoot
+from zope.component.testing import PlacelessSetup as CAPlacelessSetup
 from zope.testing import renormalizing
+from zope.traversing.interfaces import IContainmentRoot
+from zope.traversing.interfaces import ITraversable
 
-from zope.container.interfaces import IWriteContainer, INameChooser
+from zope import component
 from zope.container.contained import NameChooser
+from zope.container.interfaces import INameChooser
 from zope.container.interfaces import ISimpleReadContainer
-from zope.container.traversal import ContainerTraversable
+from zope.container.interfaces import IWriteContainer
 from zope.container.sample import SampleContainer
+from zope.container.traversal import ContainerTraversable
+
 
 checker = renormalizing.RENormalizing([
     # Python 3 unicode removed the "u".

--- a/src/zope/container/tests/constraints_example.py
+++ b/src/zope/container/tests/constraints_example.py
@@ -1,9 +1,9 @@
 from zope.interface import implementer
 from zope.location.interfaces import IContained
 
-from zope.container.interfaces import IContainer
 from zope.container.constraints import containers
 from zope.container.constraints import contains
+from zope.container.interfaces import IContainer
 
 
 class IBuddyFolder(IContainer):

--- a/src/zope/container/tests/test_btree.py
+++ b/src/zope/container/tests/test_btree.py
@@ -16,13 +16,13 @@
 import unittest
 
 from zope.interface.verify import verifyObject
+from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 
-from zope.container.tests.test_icontainer import TestSampleContainer
 from zope.container.btree import BTreeContainer
+from zope.container.contained import Contained
 from zope.container.interfaces import IBTreeContainer
 from zope.container.interfaces import IContainerModifiedEvent
-from zope.container.contained import Contained
-from zope.lifecycleevent.interfaces import IObjectRemovedEvent
+from zope.container.tests.test_icontainer import TestSampleContainer
 
 
 class TestBTreeContainer(TestSampleContainer, unittest.TestCase):

--- a/src/zope/container/tests/test_constraints.py
+++ b/src/zope/container/tests/test_constraints.py
@@ -14,6 +14,7 @@
 """Container constraint tests
 """
 import unittest
+
 import six
 
 
@@ -67,6 +68,7 @@ class TestTypesBased(unittest.TestCase):
 
 def test_suite():
     import doctest
+
     from zope.container import testing
     return unittest.TestSuite((
         unittest.defaultTestLoader.loadTestsFromName(__name__),

--- a/src/zope/container/tests/test_contained.py
+++ b/src/zope/container/tests/test_contained.py
@@ -14,22 +14,23 @@
 """Contained Tests
 """
 from __future__ import absolute_import
-import doctest
 
+import doctest
 import unittest
 
+import zope.component
+import zope.interface
 from persistent import Persistent
 
-import zope.interface
-import zope.component
-
+from zope.container import testing
 from zope.container.contained import ContainedProxy
 from zope.container.contained import NameChooser
 from zope.container.contained import contained
 from zope.container.contained import uncontained
+from zope.container.interfaces import IContainer
+from zope.container.interfaces import IReservedNames
+from zope.container.interfaces import NameReserved
 from zope.container.sample import SampleContainer
-from zope.container import testing
-from zope.container.interfaces import NameReserved, IContainer, IReservedNames
 
 
 class MyOb(Persistent):
@@ -60,8 +61,9 @@ class TestContainedProxy(unittest.TestCase):
 
     def test_declarations_on_ContainedProxy(self):
         # It is possible to make declarations on ContainedProxy objects.
-        from zope.container.interfaces import IContained
         from persistent.interfaces import IPersistent
+
+        from zope.container.interfaces import IContained
 
         class I1(zope.interface.Interface):  # pylint:disable=inherit-non-class
             pass

--- a/src/zope/container/tests/test_contained_zodb.py
+++ b/src/zope/container/tests/test_contained_zodb.py
@@ -17,13 +17,13 @@
 import gc
 import unittest
 
-from ZODB.DemoStorage import DemoStorage
-from ZODB.DB import DB
 import transaction
-
 from persistent import Persistent
+from ZODB.DB import DB
+from ZODB.DemoStorage import DemoStorage
 
 from zope.container.contained import ContainedProxy
+
 
 # pylint:disable=protected-access
 

--- a/src/zope/container/tests/test_containertraversable.py
+++ b/src/zope/container/tests/test_containertraversable.py
@@ -14,14 +14,17 @@
 """Container Traverser tests.
 """
 from __future__ import absolute_import
+
 import unittest
-from zope.testing.cleanup import CleanUp
+
+import six
+
 from zope.interface import implementer
+from zope.testing.cleanup import CleanUp
 from zope.traversing.interfaces import TraversalError
 
-from zope.container.traversal import ContainerTraversable
 from zope.container.interfaces import IContainer
-import six
+from zope.container.traversal import ContainerTraversable
 
 
 @implementer(IContainer)

--- a/src/zope/container/tests/test_containertraverser.py
+++ b/src/zope/container/tests/test_containertraverser.py
@@ -15,16 +15,19 @@
 """
 
 import unittest
-from zope.interface import Interface, implementer
-from zope import component
-from zope.publisher.interfaces import NotFound, IDefaultViewName
+
+from zope.interface import Interface
+from zope.interface import implementer
 from zope.publisher.browser import TestRequest
+from zope.publisher.interfaces import IDefaultViewName
+from zope.publisher.interfaces import NotFound
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
+from zope import component
+from zope.container import testing
+from zope.container.interfaces import IReadContainer
 from zope.container.traversal import ContainerTraverser
 from zope.container.traversal import ItemTraverser
-from zope.container.interfaces import IReadContainer
-from zope.container import testing
 
 
 @implementer(IReadContainer)

--- a/src/zope/container/tests/test_dependencies.py
+++ b/src/zope/container/tests/test_dependencies.py
@@ -7,8 +7,8 @@ from zope.publisher.interfaces.browser import IBrowserPublisher
 
 from zope.container.interfaces import IItemContainer
 from zope.container.interfaces import ISimpleReadContainer
-from zope.container.traversal import ItemTraverser
 from zope.container.testing import ContainerPlacelessSetup
+from zope.container.traversal import ItemTraverser
 
 
 class ZCMLDependencies(ContainerPlacelessSetup, unittest.TestCase):

--- a/src/zope/container/tests/test_directory.py
+++ b/src/zope/container/tests/test_directory.py
@@ -17,8 +17,8 @@
 import doctest
 import unittest
 
-from zope.container import testing
 from zope.container import directory
+from zope.container import testing
 
 
 class Directory(object):

--- a/src/zope/container/tests/test_find.py
+++ b/src/zope/container/tests/test_find.py
@@ -15,11 +15,15 @@
 """
 import unittest
 
-from zope.container.interfaces import IReadContainer
-from zope.container.interfaces import IObjectFindFilter
-from zope.container.find import FindAdapter, SimpleIdFindFilter
+from zope.interface import Interface
+from zope.interface import directlyProvides
+from zope.interface import implementer
+
+from zope.container.find import FindAdapter
+from zope.container.find import SimpleIdFindFilter
 from zope.container.find import SimpleInterfacesFindFilter
-from zope.interface import implementer, Interface, directlyProvides
+from zope.container.interfaces import IObjectFindFilter
+from zope.container.interfaces import IReadContainer
 
 
 @implementer(IReadContainer)

--- a/src/zope/container/tests/test_folder.py
+++ b/src/zope/container/tests/test_folder.py
@@ -1,9 +1,9 @@
-from unittest import TestCase, makeSuite
+import pickle
+from unittest import TestCase
+from unittest import makeSuite
 
 from zope.container.folder import Folder
 from zope.container.tests.test_icontainer import TestSampleContainer
-
-import pickle
 
 
 class Test(TestSampleContainer, TestCase):

--- a/src/zope/container/tests/test_icontainer.py
+++ b/src/zope/container/tests/test_icontainer.py
@@ -13,11 +13,14 @@
 ##############################################################################
 """Test the IContainer interface.
 """
-from unittest import TestCase, main, makeSuite
+from unittest import TestCase
+from unittest import main
+from unittest import makeSuite
 
 from zope.interface.verify import verifyObject
-from zope.container.interfaces import IContainer
+
 from zope.container import testing
+from zope.container.interfaces import IContainer
 
 
 def DefaultTestData():

--- a/src/zope/container/tests/test_ordered.py
+++ b/src/zope/container/tests/test_ordered.py
@@ -16,7 +16,9 @@
 import unittest
 from doctest import DocTestSuite
 
-from zope.component.eventtesting import getEvents, clearEvents
+from zope.component.eventtesting import clearEvents
+from zope.component.eventtesting import getEvents
+
 from zope.container import testing
 from zope.container._compat import text_type
 from zope.container.tests.test_icontainer import TestSampleContainer
@@ -27,9 +29,7 @@ class TestOrderedContainer(TestSampleContainer):
     def test_order_events(self):
         # Prepare the setup::
         from zope.container.contained import ContainerModifiedEvent
-
         # Prepare some objects::
-
         from zope.container.ordered import OrderedContainer
         oc = OrderedContainer()
         oc['foo'] = 'bar'

--- a/src/zope/container/tests/test_size.py
+++ b/src/zope/container/tests/test_size.py
@@ -17,6 +17,7 @@ import unittest
 
 from zope.interface import implementer
 from zope.size.interfaces import ISized
+
 from zope.container.interfaces import IContainer
 
 

--- a/src/zope/container/traversal.py
+++ b/src/zope/container/traversal.py
@@ -15,17 +15,23 @@
 """
 __docformat__ = 'restructuredtext'
 
-from zope.interface import implementer, providedBy
-from zope.component import queryMultiAdapter, getSiteManager
+from six.moves import map
+
 from zope.component import ComponentLookupError
-from zope.traversing.interfaces import TraversalError, ITraversable
+from zope.component import getSiteManager
+from zope.component import queryMultiAdapter
+from zope.interface import implementer
+from zope.interface import providedBy
+from zope.publisher.interfaces import IDefaultViewName
+from zope.publisher.interfaces import NotFound
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from zope.publisher.interfaces.xmlrpc import IXMLRPCPublisher
-from zope.publisher.interfaces import IDefaultViewName, NotFound
+from zope.traversing.interfaces import ITraversable
+from zope.traversing.interfaces import TraversalError
 
-from zope.container.interfaces import ISimpleReadContainer, IItemContainer
+from zope.container.interfaces import IItemContainer
 from zope.container.interfaces import IReadContainer
-from six.moves import map
+from zope.container.interfaces import ISimpleReadContainer
 
 
 # Note that the next two classes are included here because they

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38,py38-pure
     py39,py39-pure
     py310,py310-pure
+    py311,py311-pure
     pypy
     pypy3
     docs
@@ -18,6 +19,7 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = true
 deps =
 setenv =
     pure: PURE_PYTHON=1
@@ -45,15 +47,24 @@ commands =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
 commands =
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 basepython = python3
 skip_install = true
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions


### PR DESCRIPTION
Open issues:

- [x] Fix problems on MacOS for Python < 3.8
- [x] Await for 3.11.0a7 on GHA
- [x] Await for zodbpickle release supporting Python 3.11 (https://github.com/zopefoundation/zodbpickle/pull/65)
- [x] Update to use zodbpickle release.
- [x] Fix problems on Windows (AppVeyor)
- [x] Fix problems on 3.11a7, see https://github.com/python/pythoncapi-compat/issues/32
- [x] Run `meta/config` on package and fix lint problems.

Fixes #40 