### PR TITLE
Update to the latest c-code template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +105,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -153,8 +154,8 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build zope.container (3.11.0-beta.3)
-        if: ${{ startsWith(matrix.python-version, '3.11.0-beta.3') }}
+      - name: Build zope.container (3.11.0-rc.1)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -209,7 +210,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.3')
+          && !startsWith(matrix.python-version, '3.11.0-rc.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -231,7 +232,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -272,8 +273,8 @@ jobs:
         with:
           name: zope.container-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install zope.container 3.11.0-beta.3
-        if: ${{ startsWith(matrix.python-version, '3.11.0-beta.3') }}
+      - name: Install zope.container 3.11.0-rc.1
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -286,7 +287,7 @@ jobs:
           unzip -n dist/zope.container-*whl -d src
           pip install --pre -U -e .[test]
       - name: Install zope.container
-        if: ${{ !startsWith(matrix.python-version, '3.11.0-beta.3') }}
+        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -26,6 +26,20 @@ ls -ld /cache/pip
 # We need some libraries because we build wheels from scratch:
 yum -y install libffi-devel
 
+tox_env_map() {
+    case $1 in
+        *"cp27"*) echo 'py27';;
+        *"cp35"*) echo 'py35';;
+        *"cp311"*) echo 'py311';;
+        *"cp36"*) echo 'py36';;
+        *"cp37"*) echo 'py37';;
+        *"cp38"*) echo 'py38';;
+        *"cp39"*) echo 'py39';;
+        *"cp310"*) echo 'py310';;
+        *) echo 'py';;
+    esac
+}
+
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
@@ -46,8 +60,9 @@ for PYBIN in /opt/python/*/bin; do
         fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
-          "${PYBIN}/pip" install tox
-          "${PYBIN}/tox" -e py
+          ${PYBIN}/pip install tox
+          TOXENV=$(tox_env_map "${PYBIN}")
+          ${PYBIN}/tox -e ${TOXENV}
           cd ..
         fi
         rm -rf /io/build /io/*.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "ade72b5f28335a91815fd0c331ff7040c0aed1e7"
+commit-id = "94c953d3f5d8473ac80e17d9cb3d667cd97c5f98"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.7 (unreleased)
 ================
 
-- Nothing changed yet.
+- Disable unsafe math optimizations in C code.  See `pull request 46
+  <https://github.com/zopefoundation/zope.container/pull/46>`_.
 
 
 4.6 (2022-07-14)

--- a/src/zope/container/tests/test_compile_flags.py
+++ b/src/zope/container/tests/test_compile_flags.py
@@ -18,7 +18,10 @@ import unittest
 try:
     # try to load a C module for side effects
     from zope.container import _zope_container_contained  # noqa
-except ImportError:  # pragma: no cover
+except (ImportError, AttributeError):  # pragma: no cover
+    # AttributeError: module 'persistent' has no attribute 'cPersistence'
+    # is what you get if you try this when PURE_PYTHON=1 exists in the
+    # environment.
     pass
 
 

--- a/src/zope/container/tests/test_compile_flags.py
+++ b/src/zope/container/tests/test_compile_flags.py
@@ -1,0 +1,34 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+import struct
+import unittest
+
+
+try:
+    # try to load a C module for side effects
+    from zope.container import _zope_container_contained  # noqa
+except ImportError:  # pragma: no cover
+    pass
+
+
+class TestFloatingPoint(unittest.TestCase):
+
+    def test_no_fast_math_optimization(self):
+        # Building with -Ofast enables -ffast-math, which sets certain FPU
+        # flags that can cause breakage elsewhere.  A library such as BTrees
+        # has no business changing global FPU flags for the entire process.
+        zero_bits = struct.unpack("!Q", struct.pack("!d", 0.0))[0]
+        next_up = zero_bits + 1
+        smallest_subnormal = struct.unpack("!d", struct.pack("!Q", next_up))[0]
+        self.assertNotEqual(smallest_subnormal, 0.0)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = true
+pip_pre = py311: true
 deps =
 setenv =
     pure: PURE_PYTHON=1


### PR DESCRIPTION
Add a regression test for CFLAGS not having -Ofast, which is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.