### PR TITLE
Update to current persistent API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.1 (unreleased)
 ================
 
+- Update to ``persistent`` 6.0 API usage
+
 
 6.0 (2024-05-29)
 ================

--- a/src/zope/container/ordered.py
+++ b/src/zope/container/ordered.py
@@ -16,8 +16,8 @@
 __docformat__ = 'restructuredtext'
 
 from persistent import Persistent
-from persistent.dict import PersistentDict
 from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 from zope.interface import implementer
 
 from zope.container.contained import Contained
@@ -41,7 +41,7 @@ class OrderedContainer(Persistent, Contained):
 
     def __init__(self):
 
-        self._data = PersistentDict()
+        self._data = PersistentMapping()
         self._order = PersistentList()
 
     def keys(self):


### PR DESCRIPTION
Since persistent-6.0 there is `DeprecationWarning: PersistentDict is deprecated. 'persistent.dict.PersistentDict' is deprecated. Use 'persistent.mapping.PersistentMapping' instead.`