### PR TITLE
Fix test runs: make unzip less specific

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -413,7 +413,7 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U coverage[toml]
-          pip install -U  "`ls dist/zope.container-*.whl`[docs]"
+          pip install -U  "`ls dist/*.whl`[docs]"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -320,7 +320,7 @@ jobs:
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/zope.container-*whl -d src
+          unzip -n dist/*whl -d src
           pip install -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}


### PR DESCRIPTION
The wheel got a different name: zope_container… instead of zope.container…